### PR TITLE
feat(bench): added additional benchmarks

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -13,6 +13,7 @@
       "npm:jsonschema": "npm:jsonschema@1.4.1",
       "npm:oxc-transform@^0.23": "npm:oxc-transform@0.23.0",
       "npm:valibot": "npm:valibot@0.37.0",
+      "npm:yup": "npm:yup@1.4.0",
       "npm:zod": "npm:zod@3.23.8",
       "npm:zod-to-json-schema": "npm:zod-to-json-schema@3.23.0_zod@3.23.8"
     },
@@ -142,13 +143,38 @@
           "@oxc-transform/binding-win32-x64-msvc": "@oxc-transform/binding-win32-x64-msvc@0.23.0"
         }
       },
+      "property-expr@2.0.6": {
+        "integrity": "sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA==",
+        "dependencies": {}
+      },
       "require-from-string@2.0.2": {
         "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+        "dependencies": {}
+      },
+      "tiny-case@1.0.3": {
+        "integrity": "sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==",
+        "dependencies": {}
+      },
+      "toposort@2.0.2": {
+        "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==",
+        "dependencies": {}
+      },
+      "type-fest@2.19.0": {
+        "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
         "dependencies": {}
       },
       "valibot@0.37.0": {
         "integrity": "sha512-FQz52I8RXgFgOHym3XHYSREbNtkgSjF9prvMFH1nBsRyfL6SfCzoT1GuSDTlbsuPubM7/6Kbw0ZMQb8A+V+VsQ==",
         "dependencies": {}
+      },
+      "yup@1.4.0": {
+        "integrity": "sha512-wPbgkJRCqIf+OHyiTBQoJiP5PFuAXaWiJK6AmYkzQAh5/c2K9hzSApBZG5wV9KoKSePF7sAxmNSvh/13YHkFDg==",
+        "dependencies": {
+          "property-expr": "property-expr@2.0.6",
+          "tiny-case": "tiny-case@1.0.3",
+          "toposort": "toposort@2.0.2",
+          "type-fest": "type-fest@2.19.0"
+        }
       },
       "zod-to-json-schema@3.23.0_zod@3.23.8": {
         "integrity": "sha512-az0uJ243PxsRIa2x1WmNE/pnuA05gUq/JB8Lwe1EDCCL/Fz9MgjYQ0fPlyc2Tcv6aF2ZA7WM5TWaRZVEFaAIag==",

--- a/deno.lock
+++ b/deno.lock
@@ -9,6 +9,7 @@
       "jsr:@std/testing": "jsr:@std/testing@0.225.3",
       "npm:@sinclair/typebox": "npm:@sinclair/typebox@0.32.35",
       "npm:ajv": "npm:ajv@8.17.1",
+      "npm:jsonschema": "npm:jsonschema@1.4.1",
       "npm:oxc-transform@^0.23": "npm:oxc-transform@0.23.0",
       "npm:valibot": "npm:valibot@0.37.0",
       "npm:zod": "npm:zod@3.23.8",
@@ -87,6 +88,10 @@
       },
       "json-schema-traverse@1.0.0": {
         "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+        "dependencies": {}
+      },
+      "jsonschema@1.4.1": {
+        "integrity": "sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==",
         "dependencies": {}
       },
       "oxc-transform@0.23.0": {

--- a/deno.lock
+++ b/deno.lock
@@ -9,6 +9,7 @@
       "jsr:@std/testing": "jsr:@std/testing@0.225.3",
       "npm:@sinclair/typebox": "npm:@sinclair/typebox@0.32.35",
       "npm:ajv": "npm:ajv@8.17.1",
+      "npm:joi": "npm:joi@17.13.3",
       "npm:jsonschema": "npm:jsonschema@1.4.1",
       "npm:oxc-transform@^0.23": "npm:oxc-transform@0.23.0",
       "npm:valibot": "npm:valibot@0.37.0",
@@ -33,6 +34,16 @@
       }
     },
     "npm": {
+      "@hapi/hoek@9.3.0": {
+        "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
+        "dependencies": {}
+      },
+      "@hapi/topo@5.1.0": {
+        "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+        "dependencies": {
+          "@hapi/hoek": "@hapi/hoek@9.3.0"
+        }
+      },
       "@oxc-transform/binding-darwin-arm64@0.23.0": {
         "integrity": "sha512-IDTjBFaaIdkLVO2PWMxPLXnbK6PdOWbOx/rOiriWE7x5rQSlqR+8WFRkFHrQr+E3jrItE+sdsDrtOdq0lJJ+3w==",
         "dependencies": {}
@@ -65,6 +76,20 @@
         "integrity": "sha512-lkUSMK4fpUzbQ1RV2kBOSlQ2QItEbHWGzRMwUgBgWS3IyupzorOKY6G1YVQ9VvwkGDw+G/7LADRc3Yvs4Z5xFg==",
         "dependencies": {}
       },
+      "@sideway/address@4.1.5": {
+        "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
+        "dependencies": {
+          "@hapi/hoek": "@hapi/hoek@9.3.0"
+        }
+      },
+      "@sideway/formula@3.0.1": {
+        "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==",
+        "dependencies": {}
+      },
+      "@sideway/pinpoint@2.0.0": {
+        "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
+        "dependencies": {}
+      },
       "@sinclair/typebox@0.32.35": {
         "integrity": "sha512-Ul3YyOTU++to8cgNkttakC0dWvpERr6RYoHO2W47DLbFvrwBDJUY31B1sImH6JZSYc4Kt4PyHtoPNu+vL2r2dA==",
         "dependencies": {}
@@ -85,6 +110,16 @@
       "fast-uri@3.0.1": {
         "integrity": "sha512-MWipKbbYiYI0UC7cl8m/i/IWTqfC8YXsqjzybjddLsFjStroQzsHXkc73JutMvBiXmOvapk+axIl79ig5t55Bw==",
         "dependencies": {}
+      },
+      "joi@17.13.3": {
+        "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
+        "dependencies": {
+          "@hapi/hoek": "@hapi/hoek@9.3.0",
+          "@hapi/topo": "@hapi/topo@5.1.0",
+          "@sideway/address": "@sideway/address@4.1.5",
+          "@sideway/formula": "@sideway/formula@3.0.1",
+          "@sideway/pinpoint": "@sideway/pinpoint@2.0.0"
+        }
       },
       "json-schema-traverse@1.0.0": {
         "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",

--- a/deno.lock
+++ b/deno.lock
@@ -9,6 +9,7 @@
       "jsr:@std/testing": "jsr:@std/testing@0.225.3",
       "npm:@sinclair/typebox": "npm:@sinclair/typebox@0.32.35",
       "npm:oxc-transform@^0.23": "npm:oxc-transform@0.23.0",
+      "npm:valibot": "npm:valibot@0.37.0",
       "npm:zod": "npm:zod@3.23.8",
       "npm:zod-to-json-schema": "npm:zod-to-json-schema@3.23.0_zod@3.23.8"
     },
@@ -78,6 +79,10 @@
           "@oxc-transform/binding-win32-arm64-msvc": "@oxc-transform/binding-win32-arm64-msvc@0.23.0",
           "@oxc-transform/binding-win32-x64-msvc": "@oxc-transform/binding-win32-x64-msvc@0.23.0"
         }
+      },
+      "valibot@0.37.0": {
+        "integrity": "sha512-FQz52I8RXgFgOHym3XHYSREbNtkgSjF9prvMFH1nBsRyfL6SfCzoT1GuSDTlbsuPubM7/6Kbw0ZMQb8A+V+VsQ==",
+        "dependencies": {}
       },
       "zod-to-json-schema@3.23.0_zod@3.23.8": {
         "integrity": "sha512-az0uJ243PxsRIa2x1WmNE/pnuA05gUq/JB8Lwe1EDCCL/Fz9MgjYQ0fPlyc2Tcv6aF2ZA7WM5TWaRZVEFaAIag==",

--- a/deno.lock
+++ b/deno.lock
@@ -8,6 +8,7 @@
       "jsr:@std/path@^1.0": "jsr:@std/path@1.0.2",
       "jsr:@std/testing": "jsr:@std/testing@0.225.3",
       "npm:@sinclair/typebox": "npm:@sinclair/typebox@0.32.35",
+      "npm:ajv": "npm:ajv@8.17.1",
       "npm:oxc-transform@^0.23": "npm:oxc-transform@0.23.0",
       "npm:valibot": "npm:valibot@0.37.0",
       "npm:zod": "npm:zod@3.23.8",
@@ -67,6 +68,27 @@
         "integrity": "sha512-Ul3YyOTU++to8cgNkttakC0dWvpERr6RYoHO2W47DLbFvrwBDJUY31B1sImH6JZSYc4Kt4PyHtoPNu+vL2r2dA==",
         "dependencies": {}
       },
+      "ajv@8.17.1": {
+        "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+        "dependencies": {
+          "fast-deep-equal": "fast-deep-equal@3.1.3",
+          "fast-uri": "fast-uri@3.0.1",
+          "json-schema-traverse": "json-schema-traverse@1.0.0",
+          "require-from-string": "require-from-string@2.0.2"
+        }
+      },
+      "fast-deep-equal@3.1.3": {
+        "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+        "dependencies": {}
+      },
+      "fast-uri@3.0.1": {
+        "integrity": "sha512-MWipKbbYiYI0UC7cl8m/i/IWTqfC8YXsqjzybjddLsFjStroQzsHXkc73JutMvBiXmOvapk+axIl79ig5t55Bw==",
+        "dependencies": {}
+      },
+      "json-schema-traverse@1.0.0": {
+        "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+        "dependencies": {}
+      },
       "oxc-transform@0.23.0": {
         "integrity": "sha512-0wnyvQxUpz4/HQb26NMiX+JKTPZrBAPGMUBri8oRw2M35K6AwOiVyTekwlMkymR9NbXJcLo9N656a+L52LksVQ==",
         "dependencies": {
@@ -79,6 +101,10 @@
           "@oxc-transform/binding-win32-arm64-msvc": "@oxc-transform/binding-win32-arm64-msvc@0.23.0",
           "@oxc-transform/binding-win32-x64-msvc": "@oxc-transform/binding-win32-x64-msvc@0.23.0"
         }
+      },
+      "require-from-string@2.0.2": {
+        "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+        "dependencies": {}
       },
       "valibot@0.37.0": {
         "integrity": "sha512-FQz52I8RXgFgOHym3XHYSREbNtkgSjF9prvMFH1nBsRyfL6SfCzoT1GuSDTlbsuPubM7/6Kbw0ZMQb8A+V+VsQ==",

--- a/scripts/bench.ts
+++ b/scripts/bench.ts
@@ -6,6 +6,7 @@ import * as v from 'npm:valibot';
 import { Ajv } from 'npm:ajv';
 import { Validator } from 'npm:jsonschema';
 import joi from 'npm:joi';
+import yup from 'npm:yup';
 
 Deno.bench('tschema', { group: 'builder' }, () => {
 	let _ = t.object({
@@ -203,6 +204,33 @@ Deno.bench('joi', { group: 'builder' }, () => {
 			joi.number().min(0),
 		),
 		interests: joi.array().items(joi.string().min(4).max(32).alphanum()),
+	});
+	schema.validate({
+		uid: 64298,
+		name: 'lukeed',
+		isActive: true,
+		avatar: 'https://example.com/lukeed.png',
+		achievements: 'pro',
+		interests: ['painting', 'playing games'],
+		last_updated: 1722642982,
+	});
+});
+
+Deno.bench('yup', { group: 'builder' }, () => {
+	let schema = yup.object({
+		uid: yup.number().integer(),
+		name: yup.string(),
+		isActive: yup.boolean(),
+		avatar: yup.string().url().optional(),
+		achievements: yup.mixed().oneOf([
+			'novice',
+			'pro',
+			'expert',
+			'master',
+			yup.number().min(0),
+		]),
+		interests: yup.array(yup.string().min(4).max(32)),
+		last_updated: yup.number().integer().min(0),
 	});
 	schema.validate({
 		uid: 64298,

--- a/scripts/bench.ts
+++ b/scripts/bench.ts
@@ -3,6 +3,7 @@ import { Type } from 'npm:@sinclair/typebox';
 import { zodToJsonSchema } from 'npm:zod-to-json-schema';
 import { z } from 'npm:zod';
 import * as v from 'npm:valibot'
+import { Ajv } from "npm:ajv";
 
 Deno.bench('tschema', { group: 'builder' }, () => {
 	let _ = t.object({
@@ -116,3 +117,37 @@ Deno.bench('valibot', { group: 'builder' }, () => {
 		last_updated: v.pipe(v.number('unix seconds'), v.integer(), v.minValue(0)),
 	})
 });
+
+Deno.bench('ajv', { group: 'builder' }, () => {
+	const ajv = new Ajv({ formats: { uri: true } });
+	ajv.compile({
+		type: "object",
+		properties: {
+			uid: { type: "integer" },
+			name: {
+			type: "string",
+			description: "full name",
+			examples: ["Alex Johnson"],
+			},
+			isActive: { type: "boolean" },
+			avatar: { type: "string", format: "uri" },
+			achievements: {
+			anyOf: [{ type: "string", enum: ["novice", "pro", "expert", "master"] }, {
+				type: "number",
+				minimum: 0,
+			}],
+			},
+			interests: {
+			type: "array",
+			items: { type: "string", minLength: 4, maxLength: 36 },
+			},
+			last_updated: {
+			type: "integer",
+			minimum: 0,
+			examples: [1722642982],
+			description: "unix seconds",
+			},
+		},
+		additionalProperties: false,
+	})
+})

--- a/scripts/bench.ts
+++ b/scripts/bench.ts
@@ -4,6 +4,7 @@ import { zodToJsonSchema } from 'npm:zod-to-json-schema';
 import { z } from 'npm:zod';
 import * as v from 'npm:valibot';
 import { Ajv } from 'npm:ajv';
+import { Validator } from 'npm:jsonschema';
 
 Deno.bench('tschema', { group: 'builder' }, () => {
 	let _ = t.object({
@@ -119,7 +120,7 @@ Deno.bench('valibot', { group: 'builder' }, () => {
 });
 
 Deno.bench('ajv', { group: 'builder' }, () => {
-	const ajv = new Ajv({ formats: { uri: true } });
+	let ajv = new Ajv({ formats: { uri: true } });
 	ajv.compile({
 		type: 'object',
 		properties: {
@@ -148,6 +149,44 @@ Deno.bench('ajv', { group: 'builder' }, () => {
 				description: 'unix seconds',
 			},
 		},
-		additionalProperties: false,
+	});
+});
+
+Deno.bench('jsonschema', { group: 'builder' }, () => {
+	let v = new Validator();
+	v.validate({
+		uid: 64298,
+		name: 'lukeed',
+		isActive: true,
+		avatar: 'https://example.com/lukeed.png',
+		achievements: 'pro',
+		interests: ['painting', 'playing games'],
+		last_updated: 1722642982,
+	}, {
+		type: 'object',
+		properties: {
+			uid: { type: 'integer' },
+			name: {
+				type: 'string',
+				description: 'full name',
+			},
+			isActive: { type: 'boolean' },
+			avatar: { type: 'string', format: 'uri' },
+			achievements: {
+				anyOf: [{ type: 'string', enum: ['novice', 'pro', 'expert', 'master'] }, {
+					type: 'number',
+					minimum: 0,
+				}],
+			},
+			interests: {
+				type: 'array',
+				items: { type: 'string', minLength: 4, maxLength: 36 },
+			},
+			last_updated: {
+				type: 'integer',
+				minimum: 0,
+				description: 'unix seconds',
+			},
+		},
 	});
 });

--- a/scripts/bench.ts
+++ b/scripts/bench.ts
@@ -2,6 +2,7 @@ import * as t from '../mod.ts';
 import { Type } from 'npm:@sinclair/typebox';
 import { zodToJsonSchema } from 'npm:zod-to-json-schema';
 import { z } from 'npm:zod';
+import * as v from 'npm:valibot'
 
 Deno.bench('tschema', { group: 'builder' }, () => {
 	let _ = t.object({
@@ -95,4 +96,23 @@ Deno.bench('zod-to-json-schema', { group: 'builder' }, () => {
 	});
 
 	let _ = zodToJsonSchema(zod);
+});
+
+Deno.bench('valibot', { group: 'builder' }, () => {
+	v.object({
+		uid: v.pipe(v.number(), v.integer()),
+		name: v.string('full name'),
+		isActive: v.boolean(),
+		avatar: v.optional(
+			v.pipe(v.string(), v.url()),
+		),
+		achievements: v.tuple([
+			v.pipe(v.number(), v.minValue(0)), // points
+			v.picklist(['novice', 'pro', 'expert', 'master'] as const),
+		]),
+		interests: v.array(
+			v.pipe(v.string(), v.minLength(4), v.maxLength(36)),
+		),
+		last_updated: v.pipe(v.number('unix seconds'), v.integer(), v.minValue(0)),
+	})
 });

--- a/scripts/bench.ts
+++ b/scripts/bench.ts
@@ -5,6 +5,7 @@ import { z } from 'npm:zod';
 import * as v from 'npm:valibot';
 import { Ajv } from 'npm:ajv';
 import { Validator } from 'npm:jsonschema';
+import joi from 'npm:joi';
 
 Deno.bench('tschema', { group: 'builder' }, () => {
 	let _ = t.object({
@@ -188,5 +189,28 @@ Deno.bench('jsonschema', { group: 'builder' }, () => {
 				description: 'unix seconds',
 			},
 		},
+	});
+});
+
+Deno.bench('joi', { group: 'builder' }, () => {
+	let schema = joi.object({
+		uid: joi.number().integer(),
+		name: joi.string().description('full name').example('Alex Johnson'),
+		isActive: joi.boolean(),
+		avatar: joi.string().uri().optional(),
+		achievements: joi.alternatives().try(
+			joi.string().valid('novice', 'pro', 'expert', 'master'),
+			joi.number().min(0),
+		),
+		interests: joi.array().items(joi.string().min(4).max(32).alphanum()),
+	});
+	schema.validate({
+		uid: 64298,
+		name: 'lukeed',
+		isActive: true,
+		avatar: 'https://example.com/lukeed.png',
+		achievements: 'pro',
+		interests: ['painting', 'playing games'],
+		last_updated: 1722642982,
 	});
 });

--- a/scripts/bench.ts
+++ b/scripts/bench.ts
@@ -103,7 +103,7 @@ Deno.bench('zod-to-json-schema', { group: 'builder' }, () => {
 });
 
 Deno.bench('valibot', { group: 'builder' }, () => {
-	v.object({
+	let _ = v.object({
 		uid: v.pipe(v.number(), v.integer()),
 		name: v.string('full name'),
 		isActive: v.boolean(),
@@ -122,8 +122,7 @@ Deno.bench('valibot', { group: 'builder' }, () => {
 });
 
 Deno.bench('ajv', { group: 'builder' }, () => {
-	let ajv = new Ajv({ formats: { uri: true } });
-	ajv.compile({
+	let _ = new Ajv({ formats: { uri: true } }).compile({
 		type: 'object',
 		properties: {
 			uid: { type: 'integer' },
@@ -155,8 +154,7 @@ Deno.bench('ajv', { group: 'builder' }, () => {
 });
 
 Deno.bench('jsonschema', { group: 'builder' }, () => {
-	let v = new Validator();
-	v.validate({
+	let _ = new Validator().validate({
 		uid: 64298,
 		name: 'lukeed',
 		isActive: true,
@@ -194,7 +192,7 @@ Deno.bench('jsonschema', { group: 'builder' }, () => {
 });
 
 Deno.bench('joi', { group: 'builder' }, () => {
-	let schema = joi.object({
+	let _ = joi.object({
 		uid: joi.number().integer(),
 		name: joi.string().description('full name').example('Alex Johnson'),
 		isActive: joi.boolean(),
@@ -204,8 +202,8 @@ Deno.bench('joi', { group: 'builder' }, () => {
 			joi.number().min(0),
 		),
 		interests: joi.array().items(joi.string().min(4).max(32).alphanum()),
-	});
-	schema.validate({
+		last_updated: joi.number().integer().min(0).description('unix seconds'),
+	}).validate({
 		uid: 64298,
 		name: 'lukeed',
 		isActive: true,
@@ -217,7 +215,7 @@ Deno.bench('joi', { group: 'builder' }, () => {
 });
 
 Deno.bench('yup', { group: 'builder' }, () => {
-	let schema = yup.object({
+	let _ = yup.object({
 		uid: yup.number().integer(),
 		name: yup.string(),
 		isActive: yup.boolean(),
@@ -231,8 +229,7 @@ Deno.bench('yup', { group: 'builder' }, () => {
 		]),
 		interests: yup.array(yup.string().min(4).max(32)),
 		last_updated: yup.number().integer().min(0),
-	});
-	schema.validate({
+	}).validate({
 		uid: 64298,
 		name: 'lukeed',
 		isActive: true,

--- a/scripts/bench.ts
+++ b/scripts/bench.ts
@@ -2,8 +2,8 @@ import * as t from '../mod.ts';
 import { Type } from 'npm:@sinclair/typebox';
 import { zodToJsonSchema } from 'npm:zod-to-json-schema';
 import { z } from 'npm:zod';
-import * as v from 'npm:valibot'
-import { Ajv } from "npm:ajv";
+import * as v from 'npm:valibot';
+import { Ajv } from 'npm:ajv';
 
 Deno.bench('tschema', { group: 'builder' }, () => {
 	let _ = t.object({
@@ -115,39 +115,39 @@ Deno.bench('valibot', { group: 'builder' }, () => {
 			v.pipe(v.string(), v.minLength(4), v.maxLength(36)),
 		),
 		last_updated: v.pipe(v.number('unix seconds'), v.integer(), v.minValue(0)),
-	})
+	});
 });
 
 Deno.bench('ajv', { group: 'builder' }, () => {
 	const ajv = new Ajv({ formats: { uri: true } });
 	ajv.compile({
-		type: "object",
+		type: 'object',
 		properties: {
-			uid: { type: "integer" },
+			uid: { type: 'integer' },
 			name: {
-			type: "string",
-			description: "full name",
-			examples: ["Alex Johnson"],
+				type: 'string',
+				description: 'full name',
+				examples: ['Alex Johnson'],
 			},
-			isActive: { type: "boolean" },
-			avatar: { type: "string", format: "uri" },
+			isActive: { type: 'boolean' },
+			avatar: { type: 'string', format: 'uri' },
 			achievements: {
-			anyOf: [{ type: "string", enum: ["novice", "pro", "expert", "master"] }, {
-				type: "number",
-				minimum: 0,
-			}],
+				anyOf: [{ type: 'string', enum: ['novice', 'pro', 'expert', 'master'] }, {
+					type: 'number',
+					minimum: 0,
+				}],
 			},
 			interests: {
-			type: "array",
-			items: { type: "string", minLength: 4, maxLength: 36 },
+				type: 'array',
+				items: { type: 'string', minLength: 4, maxLength: 36 },
 			},
 			last_updated: {
-			type: "integer",
-			minimum: 0,
-			examples: [1722642982],
-			description: "unix seconds",
+				type: 'integer',
+				minimum: 0,
+				examples: [1722642982],
+				description: 'unix seconds',
 			},
 		},
 		additionalProperties: false,
-	})
-})
+	});
+});


### PR DESCRIPTION
This pull request adds additional benchmarks to the tschema library. List the specific benchmarks that have been added.

- [x] [valibot](https://valibot.dev)
- [x] [ajv](https://ajv.js.org/)
- [x] [jsonschema](https://www.npmjs.com/package/jsonschema)
- [x] [joi](https://joi.dev/)
- [x] [yup](https://github.com/jquense/yup)

## Benchmark results
![image](https://github.com/user-attachments/assets/85720fdd-1234-485c-a11a-f871c52242ca)
